### PR TITLE
modified the nav and added some placeholders for images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/node": "20.4.0",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
+        "aos": "^3.0.0-beta.6",
         "autoprefixer": "10.4.14",
         "eslint": "8.44.0",
         "eslint-config-next": "13.4.8",
@@ -21,6 +22,9 @@
         "react-icons": "^4.10.1",
         "tailwindcss": "3.3.2",
         "typescript": "5.1.6"
+      },
+      "devDependencies": {
+        "@types/aos": "^3.0.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -395,6 +399,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aos": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/aos/-/aos-3.0.7.tgz",
+      "integrity": "sha512-sEhyFqvKauUJZDbvAB3Pggynrq6g+2PS4XB3tmUr+mDL1gfDJnwslUC4QQ7/l8UD+LWpr3RxZVR/rHoZrLqZVg==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -600,6 +610,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aos": {
+      "version": "3.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-3.0.0-beta.6.tgz",
+      "integrity": "sha512-VLWrpq8bfAWcetynVHMMrqdC+89Qq/Ym6UBJbHB4crIwp3RR8uq1dNGgsFzoDl03S43rlVMK+na3r5+oUCZsYw==",
+      "dependencies": {
+        "classlist-polyfill": "^1.2.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1"
       }
     },
     "node_modules/arg": {
@@ -974,6 +994,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -2608,10 +2633,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -4,48 +4,48 @@ import Link from "next/link";
 export default function Footer() {
   return (
     <>
-      <footer className="text-text bg-accent font-montserrat text-sm py-2 ">
-        <div className="md:w-1/3 mx-auto flex flex-col flex-shrink">
-          <div className="flex flex-col md:flex-row justify-center items-center gap-4">
+      <footer className="py-2 text-sm text-text bg-accent font-montserrat ">
+        <div className="flex flex-col flex-shrink mx-auto md:w-1/3">
+          <div className="flex flex-col items-center justify-center gap-4 md:flex-row">
             <Link
               href="/"
-              className="my-2 w-48 text-center transition duration-150 hover:text-white hover:scale-110"
+              className="w-48 my-2 text-center transition duration-150 hover:text-white hover:scale-110"
             >
               Home
             </Link>
             <Link
               href="/about"
-              className="my-2 w-48 text-center transition duration-150 hover:text-white hover:scale-110"
+              className="w-48 my-2 text-center transition duration-150 hover:text-white hover:scale-110"
             >
               About
             </Link>
             <Link
               href="/Talks"
-              className="my-2 w-48 text-center transition duration-150 hover:text-white hover:scale-110"
+              className="w-48 my-2 text-center transition duration-150 hover:text-white hover:scale-110"
             >
               Talks
             </Link>
-            <a
-              href="https://www.eventbrite.com/e/lextalktech-oct-12-2023-tickets-716404403857"
-              className="my-2 w-48 text-center transition duration-150 hover:text-white hover:scale-110"
-            >
-              Tickets
-            </a>
             <Link
-              className="my-2 w-48 text-center whitespace-nowrap transition duration-150 hover:text-white hover:scale-110"
+              className="w-48 my-2 text-center transition duration-150 whitespace-nowrap hover:text-white hover:scale-110"
               href="/team"
             >
               Team
             </Link>
             <Link
               href="/past"
-              className="my-2 w-48 text-center whitespace-nowrap transition duration-150 hover:text-white hover:scale-110"
+              className="w-48 my-2 text-center transition duration-150 whitespace-nowrap hover:text-white hover:scale-110"
             >
               Past Talks
             </Link>
+            <a
+              href="https://www.eventbrite.com/e/lextalktech-oct-12-2023-tickets-716404403857"
+              className="w-48 my-2 text-center transition duration-150 hover:text-white hover:scale-110"
+            >
+              Tickets
+            </a>
           </div>
           <div className="flex flex-col items-center">
-            <div className="flex w-1/2 md:w-1/4 justify-center text-2xl my-2 gap-4">
+            <div className="flex justify-center w-1/2 gap-4 my-2 text-2xl md:w-1/4">
               <a
                 className="transition duration-150 hover:text-white hover:scale-110"
                 href="https://www.meetup.com/The-Bluegrass-Developers-Guild/"

--- a/src/app/Nav.tsx
+++ b/src/app/Nav.tsx
@@ -2,29 +2,39 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import logoTransparent from "./../../public/images/logoTransparent.png";
-import { FaBars, FaArrowUpRightFromSquare } from "react-icons/fa6";
+import logoTransparent from "../../public/images/logoTransparent.png";
+import {
+  FaBars,
+  FaArrowUpRightFromSquare,
+  FaAngleRight,
+} from "react-icons/fa6";
 import { useState } from "react";
 
 export default function Nav() {
   const [menu, setMenu] = useState(false);
+  const [aboutMenu, setAboutMenu] = useState(false);
 
   const toggleMenu = () => {
     setMenu(!menu);
   };
 
+  const flipMenu = () => {
+    setAboutMenu(!aboutMenu);
+  };
+
   // having this blank hides the link
-  const ticketURL = "https://www.affinna.com/event/f8142beea26e11ee8fae7facffad2127";
+  const ticketURL =
+    "https://www.affinna.com/event/f8142beea26e11ee8fae7facffad2127";
 
   return (
-    <nav className="bg-accent z-20">
-      <div className="h-24 flex flex-col lg:flex-row lg:items-center lg:justify-end text-3xl font-montserrat font-thin">
+    <nav className="z-20 bg-accent">
+      <div className="flex flex-col h-24 text-3xl font-thin lg:flex-row lg:items-center lg:justify-end font-montserrat">
         {/* Left Side  */}
-        <div className="flex h-full items-center ml-8 w-fit">
+        <div className="flex items-center h-full ml-8 w-fit">
           <FaBars className="lg:hidden" onClick={toggleMenu} />
           <Link href="/">
             <Image
-              className="relative w-44 mx-8"
+              className="relative mx-8 w-44"
               src={logoTransparent}
               alt="LexTalk Logo"
               width={1009}
@@ -36,7 +46,7 @@ export default function Nav() {
         <div
           className={`${
             menu ? "" : "hidden"
-          } lg:hidden z-20 bg-accent/75 flex flex-col w-full items-center`}
+          } lg:hidden z-20 bg-accent/90 flex flex-col w-full items-center`}
         >
           <Link href="/" className="my-4">
             Home
@@ -47,61 +57,88 @@ export default function Nav() {
           <Link href="/talks" className="my-4">
             Talks
           </Link>
-          {ticketURL &&
-          <a href={ticketURL} className="my-4 flex gap-2">
-            <FaArrowUpRightFromSquare className="text-xl" />
-            Tickets
-          </a>
-          }
           <Link href="/team" className="my-4">
             Team
           </Link>
           <Link href="/past" className="my-4">
             Past Talks
           </Link>
+          {ticketURL && (
+            <a href={ticketURL} className="flex gap-2 my-4">
+              <FaArrowUpRightFromSquare className="text-xl" />
+              Tickets
+            </a>
+          )}
         </div>
 
         {/* Desktop */}
-        <div className="lg:flex w-full justify-end gap-8 px-4 hidden">
+        <div className="justify-end hidden w-full gap-8 px-4 lg:flex">
           <Link
             href="/"
-            className="border-b-2 border-transparent duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
+            className="duration-150 border-b-2 border-transparent hover:scale-110 hover:border-text hover:-translate-y-2"
           >
             Home
           </Link>
-          <Link
-            href="/about"
-            className="border-b-2 border-transparent duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
+          <div
+            onClick={flipMenu}
+            className="duration-150 border-b-2 border-transparent hover:scale-110 "
           >
-            About
-          </Link>
-          <Link
-            href="/talks"
-            className="border-b-2 border-transparent duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
-          >
-            Talks
-          </Link>
-          {ticketURL &&
-          <a
-            href={ticketURL}
-            className="flex gap-2 border-b-2 border-transparent duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
-          >
-            <FaArrowUpRightFromSquare className="text-xl" />
-            Tickets
-          </a>
-          }
-          <Link
-            href="/team"
-            className="border-b-2 border-transparent duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
-          >
-            Team
-          </Link>
-          <Link
-            href="/past"
-            className="border-b-2 border-transparent duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
-          >
-            Past Talks
-          </Link>
+            <div className="relative flex items-center">
+              About
+              <FaAngleRight
+                className={`h-6 ${
+                  aboutMenu && `rotate-90 transition duration-110`
+                }`}
+              />
+            </div>
+            <ul
+              className={`absolute bg-primary ring ring-secondary rounded-xl p-4 ${
+                aboutMenu ? "flex flex-col" : "hidden"
+              }`}
+            >
+              <li>
+                <Link
+                  href="/about"
+                  className="duration-150 border-b-2 border-transparent hover:scale-110 hover:border-text hover:-translate-y-2"
+                >
+                  Conference
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/talks"
+                  className="duration-150 border-b-2 border-transparent hover:scale-110 hover:border-text hover:-translate-y-2"
+                >
+                  Talks
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/team"
+                  className="duration-150 border-b-2 border-transparent hover:scale-110 hover:border-text hover:-translate-y-2"
+                >
+                  Team
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/past"
+                  className="duration-150 border-b-2 border-transparent hover:scale-110 hover:border-text hover:-translate-y-2"
+                >
+                  Past Talks
+                </Link>
+              </li>
+            </ul>
+          </div>
+          {ticketURL && (
+            <a
+              href={ticketURL}
+              className="flex gap-2 duration-150 border-b-2 border-transparent hover:scale-110 hover:border-text hover:-translate-y-2"
+            >
+              <FaArrowUpRightFromSquare className="text-xl" />
+              Tickets
+            </a>
+          )}
         </div>
       </div>
     </nav>

--- a/src/app/components/Landing.tsx
+++ b/src/app/components/Landing.tsx
@@ -21,23 +21,24 @@ export const Landing: React.FC<LandingProps> = ({ date }: LandingProps) => {
         className="absolute"
         alt="Presentation at Lex Talk Tech conference"
         src={conferenceTalk}
+        placeholder="blur"
         layout="fill"
         objectFit="cover"
         objectPosition="right center"
       />
       <div>
-        <div className="h-screen-minus-nav flex flex-col items-center justify-center">
-          <div className="flex flex-col items-center h-fit bg-black/50 w-fit px-8 py-4 mx-auto z-10">
-            <h1 className="text-5xl lg:text-8xl tracking-tight leading my-4 text-center">
+        <div className="flex flex-col items-center justify-center h-screen-minus-nav">
+          <div className="z-10 flex flex-col items-center px-8 py-4 mx-auto h-fit bg-black/50 w-fit">
+            <h1 className="my-4 text-5xl tracking-tight text-center lg:text-8xl leading">
               Lex Talk Tech
             </h1>
-            <div className="flex flex-col text-2xl lg:text-3xl lg:my-8 text-center">
+            <div className="flex flex-col text-2xl text-center lg:text-3xl lg:my-8">
               <span>A quarterly tech conference in the bluegrass</span>
-              <span className="font-thin my-2 lg:my-4">{formattedDate}</span>
+              <span className="my-2 font-thin lg:my-4">{formattedDate}</span>
             </div>
             <Link
               href="https://www.affinna.com/event/f8142beea26e11ee8fae7facffad2127"
-              className="text-2xl lg:text-3xl bg-primary/50 py-3 px-6 rounded-full border border-white/25 shadow-xl backdrop-blur-sm border-b-2 duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
+              className="px-6 py-3 text-2xl duration-150 border border-b-2 rounded-full shadow-xl lg:text-3xl bg-primary/50 border-white/25 backdrop-blur-sm hover:scale-110 hover:border-text hover:-translate-y-2"
             >
               Tickets
             </Link>

--- a/src/app/components/ScheduleTable.tsx
+++ b/src/app/components/ScheduleTable.tsx
@@ -23,25 +23,25 @@ export const ScheduleTable: React.FC<ScheduleTableProps> = ({ data }) => {
         </thead>
         <tbody>
           {data.map((line, index) => (
-            <tr key={index} className="hover:scale-110 duration-100">
+            <tr key={index} className="duration-100 hover:scale-110">
               <td
                 className={`${
                   index % 2 == 0 ? "bg-accent" : "bg-background"
-                } 'm-3 font-bold'`}
+                } 'p-3 py-4 font-bold'`}
               >
                 <time>{line.time}</time>
               </td>
               <td
                 className={`${
                   index % 2 == 0 ? "bg-accent" : "bg-background"
-                } 'm-3 font-bold'`}
+                } 'p-3 py-4 font-bold'`}
               >
                 {line.topic}
               </td>
               <td
                 className={`${
                   index % 2 == 0 ? "bg-accent" : "bg-background"
-                } 'm-3 font-bold'`}
+                } 'p-3 py-4 font-bold'`}
               >
                 {line.presenter}
               </td>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,23 +61,24 @@ export default function Home() {
     <>
       <div className="font-montserrat text-text">
         <Landing date={data.date} />
-        <div className="my-12 mx-auto max-w-screen-xl px-4">
-          <div className="flex items-center w-1/3 justify-between my-8">
+        <div className="max-w-screen-xl px-4 mx-auto my-12">
+          <div className="flex items-center justify-between w-1/3 my-8">
             <h2 className="text-3xl">Schedule</h2>
             <Link
               href="/talks"
-              className="text-3xl bg-primary/50 py-3 px-6 rounded-full border border-white/25 backdrop-blur-sm border-b-2 duration-150 hover:scale-110 hover:border-text hover:-translate-y-2"
+              className="px-6 py-3 text-3xl duration-150 border border-b-2 rounded-full bg-primary/50 border-white/25 backdrop-blur-sm hover:scale-110 hover:border-text hover:-translate-y-2"
             >
               Talks
             </Link>
           </div>
           <ScheduleTable data={data.schedule} />
         </div>
-        <div className="w-screen h-screen relative">
+        <div className="relative w-screen h-screen">
           <Image
             className="absolute"
             alt="Presentation at Lex Talk Tech conference"
             src={joeTalk}
+            placeholder="blur"
             layout="fill"
             objectFit="cover"
           />

--- a/src/app/past/page.tsx
+++ b/src/app/past/page.tsx
@@ -1,23 +1,27 @@
+import Link from "next/link";
+
 export default function Past() {
   return (
     <>
-    <div className="my-12 mx-auto max-w-screen-xl px-4">
-      <h1 className="text-2xl font-cabin">
-        List of past LexTalks
-      </h1>
-      <table className="w-full text-xl md:text-3xl">
-        <tbody>
-          <tr key="1" className="">
-            <td className="m-3 font-bold">
-              <ul className="list-disc">
-                <li><a href="/past/2023-05-18">2023-05-18</a></li>
-                <li><a href="/past/2023-10-12">2023-10-12</a></li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+      <div className="max-w-screen-xl px-4 mx-auto my-12">
+        <h1 className="text-5xl font-bold font-cabin">Past LexTalks</h1>
+        <table className="w-full text-xl md:text-3xl">
+          <tbody>
+            <tr key="1" className="">
+              <td className="font-bold ">
+                <ul className="">
+                  <li className="py-2 transition duration-150 hover:scale-110 w-fit">
+                    <Link href="/past/2023-05-18">2023-05-18</Link>
+                  </li>
+                  <li className="py-2 transition duration-150 hover:scale-110 w-fit">
+                    <Link href="/past/2023-10-12">2023-10-12</Link>
+                  </li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Not as many changes as it looks like. I installed headwinds on VSCode so it reorders a bunch of the classes. Basically just cleaned up the nav and footer and made the past talks page look a tiny bit nicer. I also added placeholders for the images so they'll load a blur image quickly.